### PR TITLE
Added events for uploading announcements

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,15 @@ Next, you will need to configure helper duck. Create a file named `config.json` 
 ```
 {
   "DB_FILE": "<name of database file from above>",
+  "ANNOUNCEMENT_ENDPOINT": "<endpoint to send announcements to>",
   "MENTOR_CHANNEL_ID": <mentor private channel id from discord>,
   "HELP_CHANNEL_ID": <channel for helper duck to create threads in>,
+  "ANNOUNCEMENT_CHANNEL_ID": <channel for the hackathon announcements>,
   "GUILD_ID": <id of your hackathons discord server>,
   "MENTOR_ROLE_ID": <id of the role only mentors have in discord>,
   "ORGANIZER_ROLE_ID": <if of the role only organizers have in discord>,
-  "API_TOKEN": "<discord api token>"
+  "API_TOKEN": "<discord api token>",
+  "ANNOUNCEMENT_SECRET": "<secret for announcement endpoint authentication>"
 }
 ```
 

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 #TODO: add types
 
+from email.mime import message
 from os import getenv
 from os.path import isfile
 import nextcord as nc
@@ -10,20 +11,17 @@ from nextcord.ext import application_checks as nc_app_checks
 import logging
 import sqlite3 as sql
 import json
+import requests
 
 logging.basicConfig(level=logging.INFO)
 
 logger = logging.getLogger('nextcord')
 
+
 # Load the config.json file
 
-
 if isfile('config.json'):
-
-
     with open('config.json') as jsonfile:
-
-
         config = json.load(jsonfile)
 # Load config from an environment variable
 else:
@@ -31,9 +29,14 @@ else:
     if config_json_string is None:
         raise Exception("No config found")
     config = json.loads(config_json_string)
-bot = nc_cmd.Bot()
+
+intents = nc.Intents.default()
+intents.message_content = True
+bot = nc_cmd.Bot(intents=intents)
 
 db_connection = sql.connect(config['DB_FILE'])
+
+announcement_ids = dict()
 
 @bot.event
 async def on_ready():
@@ -574,6 +577,47 @@ async def on_raw_reaction_add(payload: nc.RawReactionActionEvent): # emoji based
     else:
         pass
 
+@bot.event
+async def on_message(message):
+    # Send announcements to the website announcement endpoint
+    if message.channel.id == config["ANNOUNCEMENT_CHANNEL_ID"] and message.author != bot.user and len(message.content) > 50:
+        try:
+            response = requests.post(config["ANNOUNCEMENT_ENDPOINT"], headers={"X-Announcement-Secret": config["ANNOUNCEMENT_SECRET"]}, json={"content": message.content, "publishedAt": message.created_at.isoformat(), "authorId": str(message.author.id), "authorName": message.author.name})
+            if response.status_code != 200:
+                raise Exception(f"Received non-200 response: {response.status_code} - {response.text}")
+            announcement = response.json().get("id")
+            announcement_ids[message.id] = announcement
+            logger.info(f"Sent announcement from {message.author.name} to announcement endpoint! The announcement ID is {announcement}")
+        except Exception as e:
+            logger.error(f"Failed to send announcement from {message.author.name}: {e}")
+
+@bot.event
+async def on_message_edit(before, after):
+    # Edit announcement on website if edited in the announcement channel
+    if before.channel.id == config["ANNOUNCEMENT_CHANNEL_ID"] and before.author != bot.user and before.content != after.content:
+        announcement_id = announcement_ids.get(before.id)
+        if announcement_id:
+            try:
+                response = requests.patch(config['ANNOUNCEMENT_ENDPOINT'], headers={"X-Announcement-Secret": config["ANNOUNCEMENT_SECRET"]}, json={"id": announcement_id, "content": after.content})
+                if response.status_code != 200:
+                    raise Exception(f"Received non-200 response: {response.status_code} - {response.text}")
+                logger.info(f"Updated announcement with ID {announcement_id} from message edit by {after.author.name}")
+            except Exception as e:
+                logger.error(f"Failed to update announcement with ID {announcement_id} from message edit by {after.author.name}: {e}")
+
+@bot.event
+async def on_message_delete(message):
+    # Delete announcement on website if deleted in the announcement channel
+    if message.channel.id == config["ANNOUNCEMENT_CHANNEL_ID"] and message.author != bot.user:
+        announcement_id = announcement_ids.get(message.id)
+        if announcement_id:
+            try:
+                response = requests.delete(config['ANNOUNCEMENT_ENDPOINT'], headers={"X-Announcement-Secret": config["ANNOUNCEMENT_SECRET"]}, json={"id": announcement_id})
+                if response.status_code != 200:
+                    raise Exception(f"Received non-200 response: {response.status_code} - {response.text}")
+                logger.info(f"Deleted announcement with ID {announcement_id} from message deletion by {message.author.name}")
+            except Exception as e:
+                logger.error(f"Failed to delete announcement with ID {announcement_id} from message deletion by {message.author.name}: {e}")
 
 async def give_role(member, guild, role_name):
     # step 1: find the Role class that has the role name

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ nextcord==3.1.1
 propcache==0.4.1
 typing_extensions==4.15.0
 yarl==1.22.0
+requests==2.33.1


### PR DESCRIPTION
This adds events for message send, edit, and delete events and checks if they are in the announcements channel, meeting select requirements.
This adds one new library to the requirements, `requests`.
This also adds new fields to config.json:
* `ANNOUNCEMENT_ENDPOINT`
* `ANNOUNCEMENT_CHANNEL_ID`
* `ANNOUNCEMENT_SECRET`
These new fields are documented in the README.

NOTE: To make this work, it requires the Message Content intent, and I also had to define intents, although I noticed these were defined in the counting game branch; there is no difference in the intents necessary for either feature.